### PR TITLE
add undefer_all to Sub::Defer

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Moo
 
   - fix type inflation in threads when types are inserted by manually
     stringifying the type first (like Type::Tiny)
+  - add undefer_all to Sub::Defer
 
 1.004001 - 2013-12-27
   - fix repository links in pod

--- a/lib/Moo.pm
+++ b/lib/Moo.pm
@@ -972,6 +972,8 @@ haarg - Graham Knop (cpan:HAARG) <haarg@cpan.org>
 
 mattp - Matt Phillips (cpan:MATTP) <mattp@cpan.org>
 
+bluefeet - Aran Deltac (cpan:BLUEFEET) <bluefeet@gmail.com>
+
 =head1 COPYRIGHT
 
 Copyright (c) 2010-2011 the Moo L</AUTHOR> and L</CONTRIBUTORS>

--- a/lib/Sub/Defer.pm
+++ b/lib/Sub/Defer.pm
@@ -8,7 +8,7 @@ use Scalar::Util qw(weaken);
 our $VERSION = '1.004001';
 $VERSION = eval $VERSION;
 
-our @EXPORT = qw(defer_sub undefer_sub);
+our @EXPORT = qw(defer_sub undefer_sub undefer_all);
 
 our %DEFERRED;
 
@@ -32,6 +32,11 @@ sub undefer_sub {
   weaken($DEFERRED{$made} = $DEFERRED{$deferred});
 
   return $made;
+}
+
+sub undefer_all {
+  undefer_sub($_) for keys %DEFERRED;
+  return;
 }
 
 sub defer_info {
@@ -103,6 +108,16 @@ If the passed coderef has been L<deferred|/defer_sub> this will "undefer" it.
 If the passed coderef has not been deferred, this will just return it.
 
 If this is confusing, take a look at the example in the L</SYNOPSIS>.
+
+=head2 undefer_all
+
+ undefer_all();
+
+This will undefer all defered subs in one go.  This can be very useful in a
+forking environment where child processes would each have to undefer the same
+subs.  By calling this just before you start forking children you can undefer
+all currently deferred subs in the parent so that the children do not have to
+do it.
 
 =head1 SUPPORT
 

--- a/t/sub-defer.t
+++ b/t/sub-defer.t
@@ -58,4 +58,20 @@ my $orig = Foo->can('four');
 is(Foo->four, 'four with a twist', 'around works');
 is(Foo->four, 'four with a twist', 'around has not been destroyed by first invocation');
 
+my $one_all_defer = defer_sub 'Foo::one_all' => sub {
+  $made{'Foo::one_all'} = sub { 'one_all' }
+};
+
+my $two_all_defer = defer_sub 'Foo::two_all' => sub {
+  $made{'Foo::two_all'} = sub { 'two_all' }
+};
+
+is( $made{'Foo::one_all'}, undef, 'one_all not made' );
+is( $made{'Foo::two_all'}, undef, 'two_all not made' );
+
+undefer_all();
+
+is( $made{'Foo::one_all'}, \&Foo::one_all, 'one_all made by undefer_all' );
+is( $made{'Foo::two_all'}, \&Foo::two_all, 'two_all made by undefer_all' );
+
 done_testing;


### PR DESCRIPTION
I talked with mst on #Moose about some performance ideas I've been thinking of.  One of them had to do with not undefering Moo subs in forked children in a starman setup.  He suggested this line of code:

```
Sub::Defer::undefer_sub($_) for keys %Sub::Defer::DEFERRED;
```

And suggested that he would not be against the idea of adding an undefer_all to Sub::Defer.

So, here it is.
