### PR TITLE
Switch from a DIE handler to an eval for munging coercion and isa errors.

### DIFF
--- a/t/accessor-isa.t
+++ b/t/accessor-isa.t
@@ -131,9 +131,7 @@ is(LazyFoo->new->less_than_three, 2, 'Correct builder value returned ok');
   has attr1 => (
     is => 'ro',
     isa => sub {
-      no warnings 'once';
-      my $attr = $Method::Generate::Accessor::CurrentAttribute;
-      die bless [@$attr{'name', 'init_arg', 'step'}], 'MyException';
+      die bless [], 'MyException';
     },
     init_arg => 'attr_1',
   );
@@ -146,15 +144,11 @@ is(
   'Exception objects passed though correctly',
 );
 
-is($e->[0], 'attr1', 'attribute name available in isa check');
-is($e->[1], 'attr_1', 'attribute init_arg available in isa check');
-is($e->[2], 'isa check', 'step available in isa check');
-
 {
   my $called;
   local $SIG{__DIE__} = sub { $called++; die $_[0] };
   my $e = exception { Fizz->new(attr_1 => 5) };
-  is($called, 1, '__DIE__ handler called if set')
+  ok($called, '__DIE__ handler called if set')
 }
 
 {


### PR DESCRIPTION
For https://rt.cpan.org/Ticket/Display.html?id=97653

The global nature of DIE handlers, even when localized, will always be
problematic.  If a default contains a chain of method calls (such as a
default which creates another object) it may go through several eval
blocks, any of which could die.  The DIE handler is hard pressed to
know which is the final error and which is an intermediate.

The need to pass through exception objects unchanged just makes this
even harder.

If the code installs its own DIE handler, the whole thing goes off
the rails.

OTOH eval blocks stack naturally.

The messy bit is writing the exception handler such that it can both
catch the exception and return the value.  I'm not convinced I
did it the best way.  It's probably faster because local is slow.

Also...
- The tests which directly referenced $CurrentAttribute are glass box and
  now make no sense.
- Any user applied DIE handlers will now trip when accessors are called.
  Such is the nature of DIE handlers.
