### PR TITLE
Add build and coverage badges to POD

### DIFF
--- a/lib/Moo.pm
+++ b/lib/Moo.pm
@@ -227,6 +227,10 @@ __END__
 
 Moo - Minimalist Object Orientation (with Moose compatibility)
 
+=for html
+<a href="https://travis-ci.org/moose/Moo"><img src="https://travis-ci.org/moose/Moo.png" alt="Travis build status"></a>
+<a href="https://coveralls.io/r/moose/Moo?branch=master"><img src="https://coveralls.io/repos/moose/Moo/badge.png" alt="Coveralls coverage status"></a>
+
 =head1 SYNOPSIS
 
  package Cat::Food;


### PR DESCRIPTION
Currently the build/coverage status is not shown anywhere on MetaCPAN/s.c.o, so, inspired by @ingy's approach, I added a `=for html` section with the badges just after the name.

If anyone has a better idea for where in the POD to put it, feel free to move it.