### PR TITLE
Exporter::Tiny

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,7 +30,7 @@ my %META = (
         'Import::Into'              => 1.002,
         'Scalar::Util'              => 0,
         'perl'                      => 5.006,
-        'Exporter'                  => 5.57,  # Import 'import'
+        'Exporter::Tiny'            => 0.040,
       },
       recommends => {
         'Class::XSAccessor'         => 1.18,

--- a/lib/Moo/_Utils.pm
+++ b/lib/Moo/_Utils.pm
@@ -12,10 +12,11 @@ use strictures 1;
 use Module::Runtime qw(use_package_optimistically module_notional_filename);
 
 use Devel::GlobalDestruction ();
-use Exporter qw(import);
+use Exporter::Tiny;
 use Moo::_mro;
 use Config;
 
+our @ISA = qw(Exporter::Tiny);
 our @EXPORT = qw(
     _getglob _install_modifier _load_module _maybe_load_module
     _get_linear_isa _getstash _install_coderef _name_coderef

--- a/lib/Sub/Defer.pm
+++ b/lib/Sub/Defer.pm
@@ -1,13 +1,14 @@
 package Sub::Defer;
 
 use strictures 1;
-use Exporter qw(import);
+use Exporter::Tiny;
 use Moo::_Utils;
 use Scalar::Util qw(weaken);
 
 our $VERSION = '1.006000';
 $VERSION = eval $VERSION;
 
+our @ISA = qw(Exporter::Tiny);
 our @EXPORT = qw(defer_sub undefer_sub undefer_all);
 
 our %DEFERRED;

--- a/lib/Sub/Quote.pm
+++ b/lib/Sub/Quote.pm
@@ -6,7 +6,7 @@ sub _clean_eval { eval $_[0] }
 
 use Sub::Defer;
 use Scalar::Util qw(weaken);
-use Exporter qw(import);
+use Exporter::Tiny;
 use B ();
 BEGIN {
   *_HAVE_PERLSTRING = defined &B::perlstring ? sub(){1} : sub(){0};
@@ -15,6 +15,7 @@ BEGIN {
 our $VERSION = '1.006000';
 $VERSION = eval $VERSION;
 
+our @ISA = qw(Exporter::Tiny);
 our @EXPORT = qw(quote_sub unquote_sub quoted_from_sub qsub);
 our @EXPORT_OK = qw(quotify capture_unroll inlinify);
 

--- a/t/accessor-handles.t
+++ b/t/accessor-handles.t
@@ -77,7 +77,7 @@ is $bar->foobot, 'beep', 'asserter checks for existence not truth, on false valu
 is $bar->foobar, 'bar', 'asserter checks for existence not truth, on undef ';
 
 ok(my $e = exception {
-  package Baz;
+  package Baz2;  # Baz already used above
   use Moo;
   has foo => ( is => 'ro', handles => 'Robot' );
   sub smash { 1 };

--- a/t/exporter-tiny.t
+++ b/t/exporter-tiny.t
@@ -1,0 +1,24 @@
+use strictures 1;
+use Test::More;
+
+{
+  package Foo;
+  use Moo -default,
+    has  => { is => "ro", -as => "has_ro" },
+    has  => { is => "rw", -as => "has_rw" };
+  
+  has_ro foo => (is => "rw");
+  has_rw bar => ();
+  has_ro baz => ();
+}
+
+my $foo = Foo->new(foo => 111, bar => 222, baz => 333);
+eval { $foo->foo(11) };
+eval { $foo->bar(22) };
+eval { $foo->baz(33) };
+
+is($foo->foo, 11,  'has_ro with explicit is=>"rw"');
+is($foo->bar, 22,  'has_rw with implicit is=>"rw"');
+is($foo->baz, 333, 'has_ro with implicit is=>"ro"');
+
+done_testing;


### PR DESCRIPTION
Here is an initial port of Moo to do its exports through Exporter::Tiny. ***Why*** you say?

* It has the potential to simplify a lot of the exporting code - breaking up those big `import` functions in Moo and Moo::Role. Each generator (`_generate_has`, `_generate_extends`, etc) gets called as a class method, so subclasses have an opportunity to override them.

* It provides some standard Exporter-like functionality, like:

```
use Moo qw( has extends with );  # don't import method modifiers
```
* It provides some Sub::Exporter-like functionality, like:

```
use Moo -default,
   has => { -as => "has_optional", is => "ro", required => 0, predicate => 1 },
   has => { -as => "has_required", is => "ro", required => 1 };
```

This branch is not "done" yet, but I'm submitting a pull request to put it on the radar.