### PR TITLE
Localise $SIG{__DIE__} when wrapping accessor exceptions (RT#99733)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Moo
 
+  - Localise $SIG{__DIE__} when wrapping accessor exceptions (RT#99733)
+
 1.006001 - 2014-10-22
   - Name the ->DOES method installed by Role::Tiny
   - don't apply threading workarounds on non-threaded perls, even if module for

--- a/lib/Method/Generate/Accessor.pm
+++ b/lib/Method/Generate/Accessor.pm
@@ -425,6 +425,7 @@ sub _wrap_attr_exception {
   .($want_return ? '  my $_return;'."\n" : '')
   .'  my $_error;'."\n"
   ."  {\n"
+  .'    local $SIG{__DIE__};'."\n"
   .'    my $_old_error = $@;'."\n"
   ."    if (!eval {\n"
   .'      $@ = $_old_error;'."\n"


### PR DESCRIPTION
We always rethrow the exception, so this makes sure that any user-set
`$SIG{__DIE__}` handler only sees the final exception.