### PR TITLE
document clearer behavior for lazy attributes

### DIFF
--- a/lib/Moo.pm
+++ b/lib/Moo.pm
@@ -666,6 +666,9 @@ C<clear_${attr_name}> if your attribute's name does not start with an
 underscore, or C<_clear_${attr_name_without_the_underscore}> if it does.
 This feature comes from L<MooseX::AttributeShortcuts>.
 
+B<NOTE:> If the attribute is C<lazy>, it will be regenerated from C<default> or
+C<builder> the next time it is accessed. If it is not lazy, it will be C<undef>.
+
 =item * C<lazy>
 
 B<Boolean>.  Set this if you want values for the attribute to be grabbed


### PR DESCRIPTION
When the attribute is lazy, it will be regenerated the next time it is
accessed. If it is not lazy, it will remain undef.

I ran across this, expecting my default sub to be called again, but my attribute was not lazy. This matches with Moose's behavior though, so this is a doc-only patch. (see gist https://gist.github.com/preaction/566e2f27954f57d56a74)