### PR TITLE
Cleanup some documentation to make it more newbie friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Moo
 Moo is a minimalist Object Orientation system for Perl 5 that aims to be fully
 interoperable with Moose.
 
-  * [Moo on CPAN](https://metacpan.org/pod/Moo)
+  * [Moo on CPAN](https://metacpan.org/pod/Moo) contains the main documentation
   * [Role::Tiny on CPAN](https://metacpan.org/pod/Role::Tiny)
   * [Moose on CPAN](https://metacpan.org/pod/Moose)
 

--- a/lib/Moo.pm
+++ b/lib/Moo.pm
@@ -272,15 +272,17 @@ And elsewhere:
 
 =head1 DESCRIPTION
 
-This module is an extremely light-weight subset of L<Moose> optimised for
-rapid startup and "pay only for what you use".
+C<Moo> is an extremely light-weight Object Orientation system. It allows one to
+concisely define objects and roles with a convenient syntax that avoids the
+details of Perl's object system.  C<Moo> contains a subset of L<Moose> and is
+optimised for rapid startup.
 
-It also avoids depending on any XS modules to allow simple deployments.  The
-name C<Moo> is based on the idea that it provides almost -- but not quite -- two
-thirds of L<Moose>.
+C<Moo> avoids depending on any XS modules to allow for simple deployments.  The
+name C<Moo> is based on the idea that it provides almost -- but not quite --
+two thirds of L<Moose>.
 
 Unlike L<Mouse> this module does not aim at full compatibility with
-L<Moose>'s surface syntax, preferring instead of provide full interoperability
+L<Moose>'s surface syntax, preferring instead to provide full interoperability
 via the metaclass inflation capabilities described in L</MOO AND MOOSE>.
 
 For a full list of the minor differences between L<Moose> and L<Moo>'s surface
@@ -291,32 +293,33 @@ syntax, see L</INCOMPATIBILITIES WITH MOOSE>.
 If you want a full object system with a rich Metaprotocol, L<Moose> is
 already wonderful.
 
-However, sometimes you're writing a command line script or a CGI script
-where fast startup is essential, or code designed to be deployed as a single
-file via L<App::FatPacker>, or you're writing a CPAN module and you want it
-to be usable by people with those constraints.
+But if you don't want to use L<Moose>, you may not want "less metaprotocol"
+like L<Mouse> offers, but you probalby want "no metaprotocol", which is what
+Moo provides. C<Moo> is ideal for some situations where deployment or startup
+time precludes using L<Moose> and L<Mouse>:
 
-I've tried several times to use L<Mouse> but it's 3x the size of Moo and
-takes longer to load than most of my Moo based CGI scripts take to run.
+=over 2
 
-If you don't want L<Moose>, you don't want "less metaprotocol" like L<Mouse>,
-you want "as little as possible" -- which means "no metaprotocol", which is
-what Moo provides.
+=item a command line or CGI script where fast startup is essential 
 
-Better still, if you install and load L<Moose>, we set up metaclasses for your
-L<Moo> classes and L<Moo::Role> roles, so you can use them in L<Moose> code
-without ever noticing that some of your codebase is using L<Moo>.
+=item code designed to be deployed as a single file via L<App::FatPacker>
 
-Hence, Moo exists as its name -- Minimal Object Orientation -- with a pledge
-to make it smooth to upgrade to L<Moose> when you need more than minimal
-features.
+=item a CPAN module that may be used by others in the above situations
+
+=back
+
+C<Moo> maintains transparent compatibility with L<Moose> so if you install and
+load L<Moose> you can use Moo clases and roles in L<Moose> code without
+modification.
+
+Moo -- Minimal Object Orientation -- aims to make it smooth to upgrade to
+L<Moose> when you need more than the minimal features offered by Moo.
 
 =head1 MOO AND MOOSE
 
 If L<Moo> detects L<Moose> being loaded, it will automatically register
 metaclasses for your L<Moo> and L<Moo::Role> packages, so you should be able
-to use them in L<Moose> code without anybody ever noticing you aren't using
-L<Moose> everywhere.
+to use them in L<Moose> code without modification.
 
 L<Moo> will also create L<Moose type constraints|Moose::Manual::Types> for
 L<Moo> classes and roles, so that in Moose classes C<< isa => 'MyMooClass' >>
@@ -324,10 +327,8 @@ and C<< isa => 'MyMooRole' >> work the same as for L<Moose> classes and roles.
 
 Extending a L<Moose> class or consuming a L<Moose::Role> will also work.
 
-So will extending a L<Mouse> class or consuming a L<Mouse::Role> - but note
-that we don't provide L<Mouse> metaclasses or metaroles so the other way
-around doesn't work. This feature exists for L<Any::Moose> users porting to
-L<Moo>; enabling L<Mouse> users to use L<Moo> classes is not a priority for us.
+Extending a L<Mouse> class or consuming a L<Mouse::Role> will also work. But
+note that we don't provide L<Mouse> metaclasses or metaroles.
 
 This means that there is no need for anything like L<Any::Moose> for Moo
 code - Moo and Moose code should simply interoperate without problem. To
@@ -340,14 +341,13 @@ If you need to disable the metaclass creation, add:
   no Moo::sification;
 
 to your code before Moose is loaded, but bear in mind that this switch is
-currently global and turns the mechanism off entirely so don't put this
-in library code.
+global and turns the mechanism off entirely so don't put this in library code.
 
 =head1 MOO AND CLASS::XSACCESSOR
 
 If a new enough version of L<Class::XSAccessor> is available, it
 will be used to generate simple accessors, readers, and writers for
-a speed boost.  Simple accessors are those without lazy defaults,
+better performance.  Simple accessors are those without lazy defaults,
 type checks/coercions, or triggers.  Readers and writers generated
 by L<Class::XSAccessor> will behave slightly differently: they will
 reject attempts to call them with the incorrect number of parameters.
@@ -441,10 +441,10 @@ Returns true if the object composes in the passed role.
 
  extends 'Parent::Class';
 
-Declares base class. Multiple superclasses can be passed for multiple
-inheritance (but please use roles instead).  The class will be loaded, however
-no errors will be triggered if it can't be found and there are already subs in
-the class.
+Declares a base class. Multiple superclasses can be passed for multiple
+inheritance but please consider using L<roles|Moo::Role> instead.  The class
+will be loaded but no errors will be triggered if the class can't be found and
+there are already subs in the class.
 
 Calling extends more than once will REPLACE your superclasses, not add to
 them like 'use base' would.
@@ -458,8 +458,9 @@ or
  with 'Some::Role1', 'Some::Role2';
 
 Composes one or more L<Moo::Role> (or L<Role::Tiny>) roles into the current
-class.  An error will be raised if these roles have conflicting methods.  The
-roles will be loaded using the same mechansim as C<extends> uses.
+class.  An error will be raised if these roles cannot be composed because they
+have conflicting method definitions.  The roles will be loaded using the same
+mechansim as C<extends> uses.
 
 =head2 has
 
@@ -492,8 +493,9 @@ The options for C<has> are as follows:
 
 B<required>, may be C<ro>, C<lazy>, C<rwp> or C<rw>.
 
-C<ro> generates an accessor that dies if you attempt to write to it - i.e.
-a getter only - by defaulting C<reader> to the name of the attribute.
+C<ro> stands for "read-only" and generates an accessor that dies if you attempt
+to write to it - i.e.  a getter only - by defaulting C<reader> to the name of
+the attribute.
 
 C<lazy> generates a reader like C<ro>, but also sets C<lazy> to 1 and
 C<builder> to C<_build_${attribute_name}> to allow on-demand generated
@@ -503,26 +505,28 @@ L<MooseX::AttributeShortcuts>. There is, however, nothing to stop you
 using C<lazy> and C<builder> yourself with C<rwp> or C<rw> - it's just that
 this isn't generally a good idea so we don't provide a shortcut for it.
 
-C<rwp> generates a reader like C<ro>, but also sets C<writer> to
-C<_set_${attribute_name}> for attributes that are designed to be written
-from inside of the class, but read-only from outside.
+C<rwp> stands for "read-write protected" and generates a reader like C<ro>, but
+also sets C<writer> to C<_set_${attribute_name}> for attributes that are
+designed to be written from inside of the class, but read-only from outside.
 This feature comes from L<MooseX::AttributeShortcuts>.
 
-C<rw> generates a normal getter/setter by defaulting C<accessor> to the
-name of the attribute.
+C<rw> stands for "read-write" and generates a normal getter/setter by
+defaulting the C<accessor> to the name of the attribute specified.
 
 =item * C<isa>
 
-Takes a coderef which is meant to validate the attribute.  Unlike L<Moose>, Moo
+Takes a coderef which is used to validate the attribute.  Unlike L<Moose>, Moo
 does not include a basic type system, so instead of doing C<< isa => 'Num' >>,
 one should do
 
+ use Scalar::Util qw(looks_like_number);
+ ...
  isa => sub {
    die "$_[0] is not a number!" unless looks_like_number $_[0]
  },
 
-Note that the return value is ignored, only whether the sub lives or
-dies matters.
+Note that the return value for C<isa> is discarded. Only if the sub dies does
+type validation fail.
 
 L<Sub::Quote aware|/SUB QUOTE AWARE>
 
@@ -557,7 +561,7 @@ do something like the following:
    $_[0] % 2 ? $_[0] : $_[0] + 1
  },
 
-Note that L<Moo> will always fire your coercion: this is to permit
+Note that L<Moo> will always execute your coercion: this is to permit
 C<isa> entries to be used purely for bug trapping, whereas coercions are
 always structural to your code. We do, however, apply any supplied C<isa>
 check after the coercion has run to ensure that it returned a valid value.
@@ -573,7 +577,7 @@ Takes a string
 
   handles => 'RobotRole'
 
-Where C<RobotRole> is a role (L<Moo::Role>) that defines an interface which
+Where C<RobotRole> is a L<role|Moo::Role> that defines an interface which
 becomes the list of methods to handle.
 
 Takes a list of methods
@@ -589,7 +593,7 @@ Takes a hashref
 =item * C<trigger>
 
 Takes a coderef which will get called any time the attribute is set. This
-includes the constructor, but not default or built values. Coderef will be
+includes the constructor, but not default or built values. The coderef will be
 invoked against the object with the new value as an argument.
 
 If you set this to just C<1>, it generates a trigger which calls the
@@ -603,10 +607,10 @@ L<Sub::Quote aware|/SUB QUOTE AWARE>
 
 =item * C<default>
 
-Takes a coderef which will get called with $self as its only argument
-to populate an attribute if no value is supplied to the constructor - or
-if the attribute is lazy, when the attribute is first retrieved if no
-value has yet been provided.
+Takes a coderef which will get called with $self as its only argument to
+populate an attribute if no value for that attribute was supplied to the
+constructor. Alternatively, if the attribute is lazy, C<default> executes when
+the attribute is first retrieved if no value has yet been provided.
 
 If a simple scalar is provided, it will be inlined as a string. Any non-code
 reference (hash, array) will result in an error - for that case instead use
@@ -667,13 +671,12 @@ another attribute to be set.
 
 =item * C<required>
 
-B<Boolean>.  Set this if the attribute must be passed on instantiation.
+B<Boolean>.  Set this if the attribute must be passed on object instantiation.
 
 =item * C<reader>
 
-The value of this attribute will be the name of the method to get the value of
-the attribute.  If you like Java style methods, you might set this to
-C<get_foo>
+The name of the method that returns the value of the attribute.  If you like
+Java style methods, you might set this to C<get_foo>
 
 =item * C<writer>
 
@@ -684,8 +687,8 @@ C<set_foo>.
 =item * C<weak_ref>
 
 B<Boolean>.  Set this if you want the reference that the attribute contains to
-be weakened; use this when circular references are possible, which will cause
-leaks.
+be weakened. Use this when circular references, which cause memory leaks, are
+possible.
 
 =item * C<init_arg>
 
@@ -798,15 +801,15 @@ L<Moo::Role>s behave slightly differently.  Since their methods are
 composed into the consuming class, they can do a little more for you
 automatically.  As long as you declare your imports before calling
 C<use Moo::Role>, those imports and the ones L<Moo::Role> itself
-provides will not be composed into consuming classes, so there's usually
+provides will not be composed into consuming classes so there's usually
 no need to use L<namespace::clean>.
 
 B<On L<namespace::autoclean>:> If you're coming to Moo from the Moose
 world, you may be accustomed to using L<namespace::autoclean> in all
-your packages. This is not recommended for L<Moo> packages, because
+your packages. This is B<not> recommended for L<Moo> packages, because
 L<namespace::autoclean> will inflate your class to a full L<Moose>
 class.  It'll work, but you will lose the benefits of L<Moo>.  Instead
-you are recommended to just use L<namespace::clean>.
+just use L<namespace::clean>.
 
 =head1 INCOMPATIBILITIES WITH MOOSE
 
@@ -823,9 +826,9 @@ C<initializer> is not supported in core since the author considers it to be a
 bad idea and Moose best practices recommend avoiding it. Meanwhile C<trigger> or
 C<coerce> are more likely to be able to fulfill your needs.
 
-There is no meta object.  If you need this level of complexity you wanted
-L<Moose> - Moo succeeds at being small because it explicitly does not
-provide a metaprotocol. However, if you load L<Moose>, then
+There is no meta object.  If you need this level of complexity you need
+L<Moose> - Moo is small because it explicitly does not provide a metaprotocol.
+However, if you load L<Moose>, then
 
   Class::MOP::class_of($moo_class_or_role)
 
@@ -874,10 +877,10 @@ C<BUILDARGS> is not triggered if your class does not have any attributes.
 Without attributes, C<BUILDARGS> return value would be ignored, so we just
 skip calling the method instead.
 
-Handling of warnings: when you C<use Moo> we enable FATAL warnings, and some
-several extra pragmas when used in development: L<indirect>,
-L<multidimensional>, and L<bareword::filehandles>.  See the L<strictures>
-documentation for the details on this.
+Handling of warnings: when you C<use Moo> we enable FATAL warnings, and several
+extra pragmas when used in development: L<indirect>, L<multidimensional>, and
+L<bareword::filehandles>.  See the L<strictures> documentation for the details
+on this.
 
 A similar invocation for L<Moose> would be:
 
@@ -975,7 +978,7 @@ bluefeet - Aran Deltac (cpan:BLUEFEET) <bluefeet@gmail.com>
 
 =head1 COPYRIGHT
 
-Copyright (c) 2010-2011 the Moo L</AUTHOR> and L</CONTRIBUTORS>
+Copyright (c) 2010-2015 the Moo L</AUTHOR> and L</CONTRIBUTORS>
 as listed above.
 
 =head1 LICENSE


### PR DESCRIPTION
I am partaking in NEILB's CPAN monthly pull request challenge and I was given the Moo module.  I emailed briefly with HAARG about contributing some small edits to the main documentation to make it a little more newbie friendly.

These are the edits that I think clarify a bit of the how, what, and why of Moo.  As a total Moo newbie I am simultaneously extremely qualified and extremely unqualified to write these docs, so any feedback is appreciated.

Also, a few questions:

  * A number of places in the POD the word "Moo" is a link (i.e. L<Moo>) and in some other places it is in a fixed-width font (i.e. C<Moo>).  Should we choose just one or the other?
  * A few of the main function descriptions weren't clear to me:
    * Some of the text on the "is => lazy" attribute is a bit complicated.
    * handles takes a string, arrayref, and a hashref but it doesn't specify how those are different
    * it took me a while to understand the predicate attribute but I'm not really sure of a better way to write it
  * Is there a better ordering of the functions in the POD?
  * Should we include a more in-depth description of the problems with circular references and weak references?  Is this a common problem that people using M* will face?

Thanks!

Bob 