### PR TITLE
Neither can_haz_subutil or can_haz_subname are set when both Sub::Name and Sub::Util are loaded

### DIFF
--- a/lib/Moo/_Utils.pm
+++ b/lib/Moo/_Utils.pm
@@ -6,8 +6,10 @@ sub _getglob { \*{$_[0]} }
 sub _getstash { \%{"$_[0]::"} }
 
 use constant lt_5_8_3 => ( $] < 5.008003 or $ENV{MOO_TEST_PRE_583} ) ? 1 : 0;
-use constant can_haz_subutil => !$INC{"Sub/Name.pm"} && eval { require Sub::Util };
-use constant can_haz_subname => !$INC{"Sub/Util.pm"} && eval { require Sub::Name };
+use constant can_haz_subutil => $INC{"Sub/Util.pm"}
+    || ( !$INC{"Sub/Name.pm"} && eval { require Sub::Util } );
+use constant can_haz_subname => $INC{"Sub/Name.pm"}
+    || ( !$INC{"Sub/Util.pm"} && eval { require Sub::Name } );
 
 use Moo::_strictures;
 use Module::Runtime qw(use_package_optimistically module_notional_filename);

--- a/t/moo-utils-_name_coderef.t
+++ b/t/moo-utils-_name_coderef.t
@@ -1,0 +1,13 @@
+use Test::More;
+
+local $INC{'Sub/Name.pm'} = 1;
+local $INC{'Sub/Util.pm'} = 1;
+
+require Moo::_Utils;
+
+ok( Moo::_Utils->can_haz_subname || Moo::_Utils->can_haz_subutil,
+    "one of can_haz_subname or can_haz_subutil set with both loaded"
+);
+
+done_testing;
+


### PR DESCRIPTION
RT ticket to follow (submitted by JETEVE)

Neither constant is set if both Sub::Name and Sub::Util have already been loaded, so sub _name_coderef used neither module.

thanks,
Michael

