### PR TITLE
Ignore version constraints in extends and with statements

### DIFF
--- a/lib/Moo.pm
+++ b/lib/Moo.pm
@@ -90,7 +90,10 @@ sub unimport {
 sub _set_superclasses {
   my $class = shift;
   my $target = shift;
+  my @classes;
   foreach my $superclass (@_) {
+    next if ref($superclass) eq 'HASH';
+    push @classes, $superclass;
     _load_module($superclass);
     if ($INC{'Role/Tiny.pm'} && Role::Tiny->is_role($superclass)) {
       require Carp;
@@ -98,7 +101,7 @@ sub _set_superclasses {
     }
   }
   # Can't do *{...} = \@_ or 5.10.0's mro.pm stops seeing @ISA
-  @{*{_getglob("${target}::ISA")}{ARRAY}} = @_;
+  @{*{_getglob("${target}::ISA")}{ARRAY}} = @classes;
   if (my $old = delete $Moo::MAKERS{$target}{constructor}) {
     $old->assert_constructor;
     delete _getstash($target)->{new};
@@ -110,7 +113,7 @@ sub _set_superclasses {
   }
   no warnings 'once'; # piss off. -- mst
   $Moo::HandleMoose::MOUSE{$target} = [
-    grep defined, map Mouse::Util::find_meta($_), @_
+    grep defined, map Mouse::Util::find_meta($_), @classes
   ] if Mouse::Util->can('find_meta');
 }
 
@@ -460,7 +463,10 @@ Returns true if the object composes in the passed role.
 Declares a base class. Multiple superclasses can be passed for multiple
 inheritance but please consider using L<roles|Moo::Role> instead.  The class
 will be loaded but no errors will be triggered if the class can't be found and
-there are already subs in the class.
+there are already subs in the class. Ignores version constraints if specifies 
+like so.
+
+ extends 'Parent::Class' => { -version => 1.022 };
 
 Calling extends more than once will REPLACE your superclasses, not add to
 them like 'use base' would.
@@ -472,6 +478,12 @@ them like 'use base' would.
 or
 
  with 'Some::Role1', 'Some::Role2';
+
+or ignores the version constraints if specified like so to maintain syntax 
+compatiblity with L<Moose::Role>.
+
+ with 'Some::Role1' => { -version => 0.023 },
+      'Some::Role2' => { -version => 4.32 };
 
 Composes one or more L<Moo::Role> (or L<Role::Tiny>) roles into the current
 class.  An error will be raised if these roles cannot be composed because they

--- a/lib/Moo/Role.pm
+++ b/lib/Moo/Role.pm
@@ -254,12 +254,15 @@ sub role_application_steps {
 
 sub apply_roles_to_package {
   my ($me, $to, @roles) = @_;
+  my @cleaned_roles;
   foreach my $role (@roles) {
+    next if ref($role) eq 'HASH';
+    push @cleaned_roles, $role;
     _load_module($role);
     $me->_inhale_if_moose($role);
     die "${role} is not a Moo::Role" unless $me->is_role($role);
   }
-  $me->SUPER::apply_roles_to_package($to, @roles);
+  $me->SUPER::apply_roles_to_package($to, @cleaned_roles);
 }
 
 sub apply_single_role_to_package {


### PR DESCRIPTION
Hi There,
I just made these changes to avoid breaking things when Roles or classes are moved over from Moose.
I also added these because by specifying version constraints in extends, My dzil configuration(like for most others who use dzil) automatically picks up version constraints when parsing the module, these version constraints are then automatically placed in the Makefile.PL so version constraints can still be maintained at install-time. That lets me maintain cleanliness in my dependency chains.
Hope this helps,
-Shantanu Bhadoria