### PR TITLE
Support for required init_arg with spaces

### DIFF
--- a/lib/Method/Generate/Constructor.pm
+++ b/lib/Method/Generate/Constructor.pm
@@ -231,8 +231,10 @@ sub _check_required {
         $s{required} and not($s{builder} or $s{default})
       } sort keys %$spec;
   return '' unless @required_init;
-  '    if (my @missing = grep !exists $args->{$_}, qw('
-    .join(' ',@required_init).')) {'."\n"
+  '    if (my @missing = grep !exists $args->{$_}, \''
+    .join("','",
+        map (index($_,"'")<0? $_ : do { my $x= $_; $x =~ s/'/\\'/g; $x }), @required_init
+        )."') {\n"
     .q{      die "Missing required arguments: ".join(', ', sort @missing);}."\n"
     ."    }\n";
 }

--- a/lib/Method/Generate/Constructor.pm
+++ b/lib/Method/Generate/Constructor.pm
@@ -233,7 +233,7 @@ sub _check_required {
   return '' unless @required_init;
   '    if (my @missing = grep !exists $args->{$_}, \''
     .join("','",
-        map { index($_,"'")<0? $_ : do { my $x= $_; $x =~ s/'/\\'/g; $x } } @required_init
+        map { index($_,"'")<0? $_ : do { my $x= $_; $x =~ s/([\\\'])/\\$1/g; $x } } @required_init
         )."') {\n"
     .q{      die "Missing required arguments: ".join(', ', sort @missing);}."\n"
     ."    }\n";

--- a/lib/Method/Generate/Constructor.pm
+++ b/lib/Method/Generate/Constructor.pm
@@ -233,7 +233,7 @@ sub _check_required {
   return '' unless @required_init;
   '    if (my @missing = grep !exists $args->{$_}, \''
     .join("','",
-        map (index($_,"'")<0? $_ : do { my $x= $_; $x =~ s/'/\\'/g; $x }), @required_init
+        map { index($_,"'")<0? $_ : do { my $x= $_; $x =~ s/'/\\'/g; $x } } @required_init
         )."') {\n"
     .q{      die "Missing required arguments: ".join(', ', sort @missing);}."\n"
     ."    }\n";

--- a/t/init-arg.t
+++ b/t/init-arg.t
@@ -72,4 +72,25 @@ like(
   "lazy init_arg",
 );
 
+{
+  package Bar;
+  
+  use Moo;
+  
+  has sane_key_name => (
+    is => 'rw',
+    init_arg => 'stupid key name',
+    isa => sub { die "isa" if $_[0] % 2 },
+    required => 1
+  );
+}
+
+my $bar;
+is(
+  exception { $bar= Bar->new('stupid key name' => 4) },
+  undef, 'no error requiring init_arg with spaces',
+);
+
+is( $bar->sane_key_name, 4, 'key renamed correctly' );
+
 done_testing;

--- a/t/init-arg.t
+++ b/t/init-arg.t
@@ -83,14 +83,26 @@ like(
     isa => sub { die "isa" if $_[0] % 2 },
     required => 1
   );
+  has sane_key_name2 => (
+    is => 'rw',
+    init_arg => 'complete\nnonsense\\\'key',
+    isa => sub { die "isa" if $_[0] % 2 },
+    required => 1
+  );
 }
 
 my $bar;
 is(
-  exception { $bar= Bar->new('stupid key name' => 4) },
-  undef, 'no error requiring init_arg with spaces',
+  exception {
+    $bar= Bar->new(
+      'stupid key name' => 4,
+      'complete\nnonsense\\\'key' => 6
+    )
+  },
+  undef, 'requiring init_arg with spaces and insanity',
 );
 
-is( $bar->sane_key_name, 4, 'key renamed correctly' );
+is( $bar->sane_key_name,  4, 'key renamed correctly' );
+is( $bar->sane_key_name2, 6, 'key renamed correctly' );
 
 done_testing;


### PR DESCRIPTION
Currently Moo fails to construct an object if there is an attribute with an init_arg with spaces in it which is also 'required'.
    
While keys with spaces are not a sensible thing, sometimes it is nice to be able to construct objects from hashes built by existing code that have wacky keys.

This patch adds support for it.
