### PR TITLE
Fewer NEXTSTATE ops in new

### DIFF
--- a/lib/Method/Generate/Accessor.pm
+++ b/lib/Method/Generate/Accessor.pm
@@ -518,49 +518,49 @@ sub _generate_populate_set {
       )
     }
     ($spec->{isa}
-      ? "    {\n      my \$value = ".$get_value.";\n      "
+      ? "    do {\n      my \$value = ".$get_value.";\n      "
         .$self->_generate_isa_check(
           $name, '$value', $spec->{isa}, $init_arg
-        ).";\n"
+        ).",\n"
         .'      '.$self->_generate_simple_set($me, $name, $spec, '$value').";\n"
-        ."    }\n"
-      : '    '.$self->_generate_simple_set($me, $name, $spec, $get_value).";\n"
+        ."    },\n"
+      : '    ('.$self->_generate_simple_set($me, $name, $spec, $get_value)."),\n"
     )
     .($spec->{trigger}
-      ? '    '
+      ? "    ((${test}) and ("
         .$self->_generate_trigger(
           $name, $me, $self->_generate_simple_get($me, $name, $spec),
           $spec->{trigger}
-        )." if ${test};\n"
+        ).")),\n"
       : ''
     );
   } else {
-    "    if (${test}) {\n"
+    "    ((${test}) and (\n"
       .($spec->{coerce}
-        ? "      $source = "
+        ? "      ($source = "
           .$self->_generate_coerce(
             $name, $source,
             $spec->{coerce}, $init_arg
-          ).";\n"
+          )."),\n"
         : ""
       )
       .($spec->{isa}
-        ? "      "
+        ? "      ("
           .$self->_generate_isa_check(
             $name, $source, $spec->{isa}, $init_arg
-          ).";\n"
+          )."),\n"
         : ""
       )
-      ."      ".$self->_generate_simple_set($me, $name, $spec, $source).";\n"
+      ."      (".$self->_generate_simple_set($me, $name, $spec, $source)."),\n"
       .($spec->{trigger}
-        ? "      "
+        ? "      ("
           .$self->_generate_trigger(
             $name, $me, $self->_generate_simple_get($me, $name, $spec),
             $spec->{trigger}
-          ).";\n"
+          )."),\n"
         : ""
       )
-      ."    }\n";
+      ."    )),\n";
   }
 }
 

--- a/lib/Method/Generate/BuildAll.pm
+++ b/lib/Method/Generate/BuildAll.pm
@@ -28,9 +28,9 @@ sub buildall_body_for {
     grep *{_getglob($_)}{CODE},
     map "${_}::BUILD",
     reverse @{mro::get_linear_isa($into)};
-  '    unless (('.$args.')[0]->{__no_BUILD__}) {'."\n"
-  .join('', map qq{      ${me}->${_}(${args});\n}, @builds)
-  ."   }\n";
+  '    (('.$args.')[0]->{__no_BUILD__} or ('."\n"
+  .join('', map qq{      ${me}->${_}(${args}),\n}, @builds)
+  ."    )),\n";
 }
 
 1;

--- a/lib/Method/Generate/Constructor.pm
+++ b/lib/Method/Generate/Constructor.pm
@@ -181,21 +181,16 @@ sub _generate_args_via_buildargs {
 sub _generate_args {
   my ($self) = @_;
   return <<'_EOA';
-    my $args;
-    if ( scalar @_ == 1 ) {
-        unless ( defined $_[0] && ref $_[0] eq 'HASH' ) {
-            die "Single parameters to new() must be a HASH ref"
-                ." data => ". $_[0] ."\n";
-        }
-        $args = { %{ $_[0] } };
-    }
-    elsif ( @_ % 2 ) {
-        die "The new() method for $class expects a hash reference or a"
-          . " key/value list. You passed an odd number of arguments\n";
-    }
-    else {
-        $args = {@_};
-    }
+    my $args = scalar @_ == 1
+      ? defined $_[0] && ref $_[0] eq 'HASH'
+        ? { %{ $_[0] } }
+        : die "Single parameters to new() must be a HASH ref"
+            . " data => ". $_[0] ."\n"
+      : @_ % 2
+        ? die "The new() method for $class expects a hash reference or a"
+            . " key/value list. You passed an odd number of arguments\n"
+        : {@_}
+    ;
 _EOA
 
 }

--- a/lib/Moo/Object.pm
+++ b/lib/Moo/Object.pm
@@ -28,21 +28,17 @@ sub new {
 
 # Inlined into Method::Generate::Constructor::_generate_args() - keep in sync
 sub BUILDARGS {
-    my $class = shift;
-    if ( scalar @_ == 1 ) {
-        unless ( defined $_[0] && ref $_[0] eq 'HASH' ) {
-            die "Single parameters to new() must be a HASH ref"
-                ." data => ". $_[0] ."\n";
-        }
-        return { %{ $_[0] } };
-    }
-    elsif ( @_ % 2 ) {
-        die "The new() method for $class expects a hash reference or a"
-          . " key/value list. You passed an odd number of arguments\n";
-    }
-    else {
-        return {@_};
-    }
+  my $class = shift;
+  scalar @_ == 1
+    ? defined $_[0] && ref $_[0] eq 'HASH'
+      ? { %{ $_[0] } }
+      : die "Single parameters to new() must be a HASH ref"
+          . " data => ". $_[0] ."\n"
+    : @_ % 2
+      ? die "The new() method for $class expects a hash reference or a"
+          . " key/value list. You passed an odd number of arguments\n"
+      : {@_}
+  ;
 }
 
 sub BUILDALL {


### PR DESCRIPTION
As pointed out in https://rt.cpan.org/Ticket/Display.html?id=105880, semicolons introduce NEXTSTATE ops, which are executed at runtime, whereas the comma operator does not.