### PR TITLE
RT #115518: Moo-2.002002 can't run tests on Windows w/ MS tools

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -94,9 +94,11 @@ my %MM_ARGS = (
 {
   package MY;
 
+  use File::Spec;
+
   sub test_via_harness {
     my($self, $perl, $tests) = @_;
-    $perl .= ' -It/lib -MTestEnv=$(MOO_TEST_ENV)';
+    $perl .= ' -I' . File::Spec->catdir(qw(t lib)) . ' -MTestEnv=$(MOO_TEST_ENV)';
     return $self->SUPER::test_via_harness($perl, $tests);
   }
 


### PR DESCRIPTION
[RT #115518][1]

When building Moo-2.002002 on Windows with a perl built using
MSVC 2013, `nmake test` cannot run due to a hard-coded directory
separator in the string passed to the shell.

The string is generated in `sub test_via_harness` in Makefile.PL.

The fix is to concatenate `t` and `lib` using `File::Spec->catdir`.

As `perldoc perlport` states:

> if you need to produce native paths for a native utility that
> does not understand Unix syntax ... `File::Spec` is your friend.

[1]: https://rt.cpan.org/Public/Bug/Display.html?id=115518