### PR TITLE
Qualify another ref call to CORE::ref

### DIFF
--- a/lib/Method/Generate/Constructor.pm
+++ b/lib/Method/Generate/Constructor.pm
@@ -192,7 +192,7 @@ sub _cap_call {
 sub _generate_args_via_buildargs {
   my ($self) = @_;
   q{    my $args = $class->BUILDARGS(@_);}."\n"
-  .q{    Carp::croak("BUILDARGS did not return a hashref") unless ref($args) eq 'HASH';}
+  .q{    Carp::croak("BUILDARGS did not return a hashref") unless CORE::ref($args) eq 'HASH';}
   ."\n";
 }
 


### PR DESCRIPTION
This was left out of 033241619fa2036c4cc23a3e93940dabf68193e6

