### PR TITLE
Filter option

### DIFF
--- a/t/accessor-filter.t
+++ b/t/accessor-filter.t
@@ -10,6 +10,7 @@ my %expects = (
     2 => {
         class => "MyClass2",
         in    => 2,
+        out   => 6.28,
     },
     3 => {
         class => "MyClass3",
@@ -65,10 +66,13 @@ sub run_for {
           sub { print "  filter(", join( ", ", @_ ), ")\n"; return $_[1]; },
     );
 }
+
 {
 
     package MyClass2;
     use Moo;
+
+    has multiplier => ( is => 'rw', default => 3.14, );
 
     has attr => (
         is     => 'rw',
@@ -76,10 +80,12 @@ sub run_for {
     );
 
     sub _filter_attr {
-        print "  _filter_attr(", join( ", ", @_ ), ")\n";
-        return $_[1];
+        my $this = shift;
+        my $val  = shift;
+        return $val * $this->multiplier;
     }
 }
+
 {
 
     package MyClass3;
@@ -96,6 +102,7 @@ sub run_for {
         return "COERCED into string from $_[1]";
     }
 }
+
 {
 
     package MyClass4;
@@ -116,6 +123,7 @@ sub run_for {
         return "Converted into string from $val";
     }
 }
+
 {
 
     package MyClass5;

--- a/t/accessor-filter.t
+++ b/t/accessor-filter.t
@@ -1,0 +1,147 @@
+use Moo::_strictures;
+use Test::More;
+use Test::Fatal;
+
+my %expects = (
+    1 => {
+        class => "MyClass1",
+        in    => 1,
+    },
+    2 => {
+        class => "MyClass2",
+        in    => 2,
+    },
+    3 => {
+        class => "MyClass3",
+        in    => 3,
+        out   => "COERCED into string from 3",
+    },
+    4 => {
+        class   => "MyClass4",
+        in      => 4,
+        out     => "Converted into string from 4",
+        initial => undef,
+    },
+    5 => {
+        class   => "MyClass5",
+        in      => 5,
+        out     => "Converted into string from 5",
+        initial => 123,
+    },
+);
+
+sub run_for {
+    my $classN = shift;
+
+    my $exp   = $expects{$classN};
+    my $class = $exp->{class};
+
+    my $obj = $class->new;
+
+    if ( $obj->can('prepare') ) {
+        $obj->prepare;
+    }
+
+    if ( $exp->{initial} ) {
+        is $obj->attr, $exp->{initial}, "Initial value";
+    }
+
+    my $n = $exp->{in};
+
+    $obj->attr($n);
+
+    is $obj->attr, ( exists $exp->{out} ? $exp->{out} : $n ), "after filter";
+}
+
+{
+
+    package MyClass1;
+    use Moo;
+
+    has attr => (
+        is      => 'rw',
+        builder => sub { return 3.1415926; },
+        filter =>
+          sub { print "  filter(", join( ", ", @_ ), ")\n"; return $_[1]; },
+    );
+}
+{
+
+    package MyClass2;
+    use Moo;
+
+    has attr => (
+        is     => 'rw',
+        filter => 1,
+    );
+
+    sub _filter_attr {
+        print "  _filter_attr(", join( ", ", @_ ), ")\n";
+        return $_[1];
+    }
+}
+{
+
+    package MyClass3;
+    use Moo;
+
+    has attr => (
+        is         => 'rw',
+        unknownOne => "YES!",
+        filter     => 'commonFilter',
+    );
+
+    sub commonFilter {
+        print "  commonFilter(", join( ", ", @_ ), ")\n";
+        return "COERCED into string from $_[1]";
+    }
+}
+{
+
+    package MyClass4;
+    use Moo;
+
+    has attr => (
+        is         => 'rw',
+        lazy       => 1,
+        predicate  => 1,
+        unknownOne => "YES!",
+        filter     => 'commonFilter',
+    );
+
+    sub commonFilter {
+        my $this = shift;
+        my $val  = shift;
+        print "  NOW:", $this->attr, "\n" if $this->has_attr;
+        return "Converted into string from $val";
+    }
+}
+{
+
+    package MyClass5;
+    use Moo;
+
+    has attr => (
+        is         => 'rw',
+        lazy       => 1,
+        predicate  => 1,
+        default    => 123,
+        unknownOne => "YES!",
+        filter     => 'commonFilter',
+    );
+
+    sub commonFilter {
+        my $this = shift;
+        my $val  = shift;
+        print "  NOW:", $this->attr if $this->has_attr, "\n";
+        return "Converted into string from $val";
+    }
+
+    sub prepare {
+        $_[0]->attr;
+    }
+}
+
+run_for($_) for 1 .. 5;
+
+done_testing();


### PR DESCRIPTION
This is a proof of concept implementation of 'filter' option for 'has'. t/accessor-filter.t contains sample classes utilizing the option. The purpose is to demonstrate a possible implementation of 'coerce' with object access as was discussed at TPC:NA 2017.

The idea of 'filter' option is to have a 'coerce' object method instead of a static sub. I.e. to give 'coerce'-like functionality access to the object to which its attribute belongs. A simple use case is best demonstrated by MyClass2 in t/accessor-filter.t. For sure, real life use is much wider than that and might let a developer to auto-correct attribute values depending on current running environment.

The 'filter' option accepts following values:

- a _true_ (1) – similar to 'trigger' option: makes use of _filter_attr() sub
- a string - defines method name to be called.
- a code ref

There is some space for further improvement as it is possible to have common filter method for more than one attribute. In this case it might be vital to know the name of the attribute for which the method was called. It might be passed as the last method parameter. 