### PR TITLE
Optionally disable importing warnings into caller package

### DIFF
--- a/lib/Moo.pm
+++ b/lib/Moo.pm
@@ -42,8 +42,10 @@ sub import {
   my $class = shift;
   _set_loaded(caller);
 
+  my $no_warnings = grep /:no_warnings/, @_;
+
   strict->import;
-  warnings->import;
+  warnings->import unless $no_warnings;
 
   if ($INC{'Role/Tiny.pm'} and Role::Tiny->is_role($target)) {
     croak "Cannot import Moo into a role";

--- a/t/moo.t
+++ b/t/moo.t
@@ -103,4 +103,38 @@ is(MyClass5->foo, 'foo with around', 'method modifier');
     'can extend Moo class with overridden new';
 }
 
+{
+  no strict 'refs';
+  no warnings 'redefine';
+
+  my $import = 0;
+
+  local *{"warnings::import"} = sub { $import++ };
+
+  eval  {
+    package MyClass8;
+    require Moo;
+    Moo->import;
+  };
+
+  ::is $import, 1, "use Moo imports warnings";
+}
+
+{
+  no strict 'refs';
+  no warnings 'redefine';
+
+  my $import = 0;
+
+  local *{"warnings::import"} = sub { $import++ };
+
+  eval {
+    package MyClass9;
+    require Moo;
+    Moo->import( qw(:no_warnings) );
+  };
+
+  ::is $import, 0, "use Moo :no_warnings";
+}
+
 done_testing;


### PR DESCRIPTION
Rationale: when `use Moo` comes after `use warnings qw(...)` it will clobber the list and import everything. It's kind of tedious to remember to always `use Moo` before everything else.
