### PR TITLE
Add space to codulatable error message

### DIFF
--- a/lib/Method/Generate/Accessor.pm
+++ b/lib/Method/Generate/Accessor.pm
@@ -691,7 +691,7 @@ sub _validate_codulatable {
 
   croak "Invalid $setting '"
     . ($INC{'overload.pm'} ? overload::StrVal($value) : $value)
-    . "' for $into" . $error
+    . "' for $into " . $error
     . ($appended ? " $appended" : '');
 }
 


### PR DESCRIPTION
To avoid this:
````
Invalid isa 'CODE(0x7f9e4184f9c0)' for Mason::Tidy->mason_versionis a stub at blah lbah blah line 42.
````