### PR TITLE
Update required version of Sub::Defer

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,8 +30,8 @@ my %META = (
         'Scalar::Util'              => 0,
         'perl'                      => 5.006,
         'Exporter'                  => 5.57,  # Import 'import'
-        'Sub::Quote'                => 2.003001,
-        'Sub::Defer'                => 2.003001,
+        'Sub::Quote'                => 2.005000,
+        'Sub::Defer'                => 2.005000,
       },
       recommends => {
         'Class::XSAccessor'         => 1.18,


### PR DESCRIPTION
There was a rare case that could arise in a sufficiently complex
system where a (non-constructor) method on an object could use the
coderef of the constructor for a different object type. Updating
to a newer version of Sub::Defer removes this problem.

This was not something we were able to reproduce in a controlled fashion, but we had numerous incidents per day of ` Attempt to bless into a reference at /opt/perl-5.22.0/lib/site_perl/5.22.0/Moo/Object.pm line 25.` with none in the week+ since updating to 2.005000 (I believe the fix to have been https://metacpan.org/changes/release/HAARG/Sub-Quote-2.005000#L4 but was unable to completely understand everything that was going on).