### PR TITLE
track imports after wrapped with modifiers

### DIFF
--- a/lib/Moo.pm
+++ b/lib/Moo.pm
@@ -7,6 +7,7 @@ use Moo::_Utils qw(
   _getstash
   _install_coderef
   _install_modifier
+  _install_tracked
   _load_module
   _set_loaded
   _unimport_coderefs
@@ -30,12 +31,6 @@ require Moo::sification;
 Moo::sification->import;
 
 our %MAKERS;
-
-sub _install_tracked {
-  my ($target, $name, $code) = @_;
-  $MAKERS{$target}{exports}{$name} = $code;
-  _install_coderef "${target}::${name}" => "Moo::${name}" => $code;
-}
 
 sub import {
   my $target = caller;
@@ -109,7 +104,7 @@ sub import {
 
 sub unimport {
   my $target = caller;
-  _unimport_coderefs($target, $MAKERS{$target});
+  _unimport_coderefs($target);
 }
 
 sub _set_superclasses {

--- a/lib/Moo.pm
+++ b/lib/Moo.pm
@@ -3,6 +3,7 @@ package Moo;
 use Moo::_strictures;
 use Moo::_mro;
 use Moo::_Utils qw(
+  _check_tracked
   _getglob
   _getstash
   _install_coderef
@@ -244,9 +245,12 @@ sub _concrete_methods_of {
     keys %$stash
   };
 
+  my %tracked = map +($_ => 1), _check_tracked($class, [ keys %$subs ]);
+
   return {
     map +($_ => \&{"${class}::${_}"}),
     grep !($non_methods->{$_} && $non_methods->{$_} == $subs->{$_}),
+    grep !exists $tracked{$_},
     keys %$subs
   };
 }

--- a/lib/Moo/Role.pm
+++ b/lib/Moo/Role.pm
@@ -6,6 +6,7 @@ use Moo::_Utils qw(
   _getstash
   _install_coderef
   _install_modifier
+  _install_tracked
   _load_module
   _name_coderef
   _set_loaded
@@ -41,12 +42,6 @@ our %APPLIED_TO;
 our %APPLY_DEFAULTS;
 our %COMPOSED;
 our @ON_ROLE_CREATE;
-
-sub _install_tracked {
-  my ($target, $name, $code) = @_;
-  $INFO{$target}{exports}{$name} = $code;
-  _install_coderef "${target}::${name}" => "Moo::Role::${name}" => $code;
-}
 
 sub import {
   my $target = caller;
@@ -117,7 +112,7 @@ sub meta {
 
 sub unimport {
   my $target = caller;
-  _unimport_coderefs($target, $INFO{$target});
+  _unimport_coderefs($target);
 }
 
 sub _maybe_reset_handlemoose {

--- a/lib/Moo/Role.pm
+++ b/lib/Moo/Role.pm
@@ -2,6 +2,7 @@ package Moo::Role;
 
 use Moo::_strictures;
 use Moo::_Utils qw(
+  _check_tracked
   _getglob
   _getstash
   _install_coderef
@@ -120,6 +121,19 @@ sub _maybe_reset_handlemoose {
   if ($INC{'Moo/HandleMoose.pm'} && !$Moo::sification::disabled) {
     Moo::HandleMoose::maybe_reinject_fake_metaclass_for($target);
   }
+}
+
+sub _non_methods {
+  my $self = shift;
+  my ($role) = @_;
+
+  my $non_methods = $self->SUPER::_non_methods(@_);
+
+  my $all_subs = $self->_all_subs($role);
+  $non_methods->{$_} = $all_subs->{$_}
+    for _check_tracked($role, [ keys %$all_subs ]);
+
+  return $nonmethods;
 }
 
 sub methods_provided_by {

--- a/t/no-moo.t
+++ b/t/no-moo.t
@@ -103,4 +103,22 @@ is(GlobalConflict2->has, "has!", 'has left alone');
 
 is($GlobalConflict2::after, "has!", 'package global left alone');
 
+{
+  package WrappedHas;
+  use Moo;
+
+  BEGIN {
+    after has => sub {
+      1;
+    };
+  }
+
+  has welp => (is => 'ro');
+
+  no Moo;
+}
+
+is +WrappedHas->can('has'), undef,
+  'has with modifier applied is cleaned';
+
 done_testing;


### PR DESCRIPTION
When a 'tracked' sub exists, it will be removed by `no Moo;`.  If the sub is wrapped using a modifier, which is useful for many MooX modules, it will no longer be tracked.  This moves the tracking to something more usable by MooX modules, and makes the wrapped subs continue to be tracked.

It also modifies the method tracking to take into account the tracked subs, and not include them in the method list.  Previously, excluding these subs from the method list relies on the timing of when they are installed.