### PR TITLE
drop Module::Runtime prereq

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,7 +24,6 @@ my %META = (
     runtime => {
       requires => {
         'Class::Method::Modifiers'  => '1.10',  # for RT#80194
-        'Module::Runtime'           => '0.014', # for RT#86394
         'Role::Tiny'                => '2.001004',
         'Scalar::Util'              => '1.09',
         'perl'                      => '5.006',

--- a/lib/Method/Generate/Accessor.pm
+++ b/lib/Method/Generate/Accessor.pm
@@ -1,7 +1,7 @@
 package Method::Generate::Accessor;
 
 use Moo::_strictures;
-use Moo::_Utils qw(_load_module _maybe_load_module _install_coderef);
+use Moo::_Utils qw(_load_module _maybe_load_module _install_coderef _module_name_rx);
 use Moo::Object ();
 BEGIN { our @ISA = qw(Moo::Object) }
 use Sub::Quote qw(quote_sub quoted_from_sub quotify sanitize_identifier);
@@ -30,10 +30,7 @@ BEGIN {
   $Carp::Internal{+__PACKAGE__} = 1;
 }
 
-my $module_name_only = qr/\A$Module::Runtime::module_name_rx\z/;
-
-sub _die_overwrite
-{
+sub _die_overwrite {
   my ($pkg, $method, $type) = @_;
   croak "You cannot overwrite a locally defined method ($method) with "
     . ( $type || 'an accessor' );
@@ -72,7 +69,7 @@ sub generate_method {
     }
     $spec->{builder} = '_build_'.$name if ($spec->{builder}||0) eq 1;
     croak "Invalid builder for $into->$name - not a valid method name"
-      if $spec->{builder} !~ $module_name_only;
+      if $spec->{builder} !~ _module_name_rx;
   }
   if (($spec->{predicate}||0) eq 1) {
     $spec->{predicate} = $name =~ /^_/ ? "_has${name}" : "has_${name}";

--- a/lib/Moo/_Utils.pm
+++ b/lib/Moo/_Utils.pm
@@ -18,9 +18,15 @@ BEGIN {
             : $sn ? \&Sub::Name::subname
             : sub { $_[1] };
   *_CAN_SUBNAME = ($su || $sn) ? sub(){1} : sub(){0};
-}
 
-use Module::Runtime qw(use_package_optimistically module_notional_filename);
+  *_WORK_AROUND_BROKEN_MODULE_STATE = "$]" < 5.009 ? sub(){1} : sub(){0};
+  *_WORK_AROUND_HINT_LEAKAGE
+    = "$]" < 5.011 && !("$]" >= 5.009004 && "$]" < 5.010001)
+      ? sub(){1} : sub(){0};
+
+  my $module_name_rx = qr/\A(?!\d)\w+(?:::\w+)*\z/;
+  *_module_name_rx = sub(){$module_name_rx};
+}
 
 use Exporter qw(import);
 use Config;
@@ -42,6 +48,7 @@ our @EXPORT_OK = qw(
   _install_tracked
   _load_module
   _maybe_load_module
+  _module_name_rx
   _name_coderef
   _set_loaded
   _unimport_coderefs
@@ -88,22 +95,47 @@ sub _install_tracked {
   _install_coderef("${target}::${name}", "${from}::${name}", $code);
 }
 
+sub Moo::_Util::__GUARD__::DESTROY {
+  delete $INC{$_[0]->[0]} if @{$_[0]};
+}
+
+sub _require {
+  my ($file) = @_;
+  my $guard = _WORK_AROUND_BROKEN_MODULE_STATE
+    && bless([ $file ], 'Moo::_Util::__GUARD__');
+  local %^H if _WORK_AROUND_HINT_LEAKAGE;
+  if (!eval { require $file; 1 }) {
+    my $e = $@ || "Can't locate $file";
+    my $me = __FILE__;
+    $e =~ s{ at \Q$me\E line \d+\.\n\z}{};
+    return $e;
+  }
+  pop @$guard if _WORK_AROUND_BROKEN_MODULE_STATE;
+  return undef;
+}
+
 sub _load_module {
-  my $module = $_[0];
-  my $file = eval { module_notional_filename($module) } or croak $@;
-  use_package_optimistically($module);
+  my ($module) = @_;
+  croak qq{"$module" is not a module name!}
+    unless $module =~ _module_name_rx;
+  (my $file = "$module.pm") =~ s{::}{/}g;
   return 1
     if $INC{$file};
-  my $error = $@ || "Can't locate $file";
+
+  my $e = _require $file;
+  return 1
+    if !defined $e;
 
   # can't just ->can('can') because a sub-package Foo::Bar::Baz
   # creates a 'Baz::' key in Foo::Bar's symbol table
   my $stash = _getstash($module)||{};
-  return 1 if grep +(ref($_) || *$_{CODE}), values %$stash;
+  no strict 'refs';
+  return 1 if grep +exists &{"${module}::$_"}, grep !/::\z/, keys %$stash;
   return 1
     if $INC{"Moose.pm"} && Class::MOP::class_of($module)
     or Mouse::Util->can('find_meta') && Mouse::Util::find_meta($module);
-  croak $error;
+
+  croak $e;
 }
 
 our %MAYBE_LOADED;
@@ -111,17 +143,21 @@ sub _maybe_load_module {
   my $module = $_[0];
   return $MAYBE_LOADED{$module}
     if exists $MAYBE_LOADED{$module};
-  if(! eval { use_package_optimistically($module) }) {
-    warn "$module exists but failed to load with error: $@";
-  }
-  elsif ( $INC{module_notional_filename($module)} ) {
+  (my $file = "$module.pm") =~ s{::}{/}g;
+
+  my $e = _require $file;
+  if (!defined $e) {
     return $MAYBE_LOADED{$module} = 1;
+  }
+  elsif ($e !~ /\ACan't locate \Q$file\E /) {
+    warn "$module exists but failed to load with error: $e";
   }
   return $MAYBE_LOADED{$module} = 0;
 }
 
 sub _set_loaded {
-  $INC{Module::Runtime::module_notional_filename($_[0])} ||= $_[1];
+  (my $file = "$_[0].pm") =~ s{::}{/}g;
+  $INC{$file} ||= $_[1];
 }
 
 sub _install_coderef {

--- a/xt/inflate-our-classes.t
+++ b/xt/inflate-our-classes.t
@@ -3,7 +3,6 @@ use Test::More;
 use Test::Fatal;
 
 use Moo::HandleMoose;
-use Module::Runtime qw(use_module);
 
 foreach my $class (qw(
   Method::Generate::Accessor
@@ -15,7 +14,9 @@ foreach my $class (qw(
   local $SIG{__WARN__} = sub { push @warnings, $_[0] };
 
   is exception {
-    Moo::HandleMoose::inject_real_metaclass_for(use_module($class))
+    (my $file = "$class.pm") =~ s{::}{/}g;
+    require $file;
+    Moo::HandleMoose::inject_real_metaclass_for($class);
   }, undef,
     "No exceptions inflating $class";
   ok !@warnings, "No warnings inflating $class"


### PR DESCRIPTION
We can't use the functions from Module::Runtime directly to get our
desired behavior, so the existing interfaces aren't particularly
valuable. It also has restrictions such as not allowing unicode in
module names, and bugs related to its handling of `__DIE__` hooks and
CORE::GLOBAL::die overrides.  It's also an extra dependency, which
brings a transitive dependency on Module::Build.  At this time,
Module::Runtime is unmaintained, so getting any of these issues
resolved is not viable without significant extra work.

This is probably better addressed by writing a replacement for Module::Runtime.