### PR TITLE
Fix for unable to extend roles

### DIFF
--- a/lib/Moo.pm
+++ b/lib/Moo.pm
@@ -146,7 +146,7 @@ sub _set_superclasses {
   my $target = shift;
   foreach my $superclass (@_) {
     _load_module($superclass);
-    if ($INC{'Role/Tiny.pm'} && Role::Tiny->is_role($superclass)) {
+    if ($INC{'Role/Tiny.pm'} && !Role::Tiny->is_role($superclass)) {
       croak "Can't extend role '$superclass'";
     }
   }

--- a/t/extends-role.t
+++ b/t/extends-role.t
@@ -11,7 +11,7 @@ use Test::Fatal;
 {
     package MyClass;
     use Moo;
-    ::isnt ::exception { extends "MyRole"; }, undef, "Can't extend role";
+    ::unlike ::exception { extends "MyRole"; }, qr/Can't extend role/;
 }
 
 done_testing;


### PR DESCRIPTION
Check of Role::Tiny->is_role was reversed and test
relied on exact match for exception string which had
changed and therefore never failed.